### PR TITLE
Emulators ignore logs & Open Simulator

### DIFF
--- a/src/managers/android.ts
+++ b/src/managers/android.ts
@@ -63,7 +63,8 @@ export class AndroidDeviceManager extends DeviceManager {
       { encoding: 'utf8' }
     )
       .replace(/\n$/, '')
-      .split('\n');
+      .split('\n')
+      .filter((line) => !line.startsWith('INFO'));
 
     return await Promise.all(
       emulators

--- a/src/managers/ios.ts
+++ b/src/managers/ios.ts
@@ -4,6 +4,7 @@ import { Device, DeviceState } from '../models/device';
 import { DeviceManager } from './device-manager';
 import SimCtl from 'node-simctl';
 import _ from 'lodash';
+import { execSync } from 'child_process';
 
 export class IosDeviceManager extends DeviceManager {
   private simctl: any;
@@ -35,6 +36,7 @@ export class IosDeviceManager extends DeviceManager {
       });
 
       await simclt.bootDevice();
+      execSync('open -a simulator');
       return [true, undefined];
     } catch (err) {
       return [false, err as Error];


### PR DESCRIPTION
- Ignores emulator logs if they're present because the latest version of the 'emulator' now displays logs directly within the process output.
- Open simulator view on booting a device